### PR TITLE
add queryable config parsing

### DIFF
--- a/pyzpl/__init__.py
+++ b/pyzpl/__init__.py
@@ -292,6 +292,27 @@ class ZPLnode(object):
         result = node if match else None
         return result
 
+    def __getitem__(self, child):
+        """The children of this node may be accessed like a dict. If there are multiple
+        children with the same name, the first one will be returned:
+            first = node["child"]
+
+        If the children have values, they may be selected:
+            sam = node["child=Sam"]
+
+        If no child matching the name[=value] selector exists, KeyError is raised
+        """
+        idx = child.find('=')
+        if idx > 0:
+            key = child[:idx]
+            val = (child[idx+1:],)
+        else:
+            key = child
+            val = (None,)
+        node = self.get(key, query=val)
+        if not node: raise KeyError(child)
+        return node
+
     def __match(self, args):
         node = None
         part, filt = args[0]
@@ -345,7 +366,6 @@ def load_cfg(bytes_stream, encoding='utf-8'):
     instances, returning the root node.
     """
 
-    print("Entering load_cfg")
     root = ZPLnode()
     roots = [root,]
     for propnames, value in load_stream(bytes_stream, encoding=encoding, emit_empty=True):

--- a/pyzpl/__init__.py
+++ b/pyzpl/__init__.py
@@ -348,7 +348,6 @@ def load_cfg(bytes_stream, encoding='utf-8'):
     print("Entering load_cfg")
     root = ZPLnode()
     roots = [root,]
-    prev = root
     for propnames, value in load_stream(bytes_stream, encoding=encoding, emit_empty=True):
         # call load_stream with emit_empty=True to make it return all nodes. This simplifies
         # creating sub-trees, and ensures that the maximum increate in depth is 1
@@ -361,7 +360,6 @@ def load_cfg(bytes_stream, encoding='utf-8'):
         name = propnames[-1]
         child = ZPLnode( name=name, value=value, parent=parent )
         roots.append(child)
-        prev = child
 
     return root
 

--- a/pyzpl/__init__.py
+++ b/pyzpl/__init__.py
@@ -231,17 +231,17 @@ class ZPLnode(object):
             self._level = 0
         self._children = []
 
-    def get(self, path, filter=(None,), name_sep=':'):
-        """get(path, filter=None, name_sep=':')
+    def get(self, path, query=(None,), name_sep=':'):
+        """get(path, query=None, name_sep=':')
 
-        Retrieve the node described by 'path' and (optionally) matching 'filter'
+        Retrieve the node described by 'path' and (optionally) matching 'query'
 
         path is a tuple of names, or a string of 'name_sep' delimited parts, corresponding to
         the hierarchy of nodes
 
-        filter is an optional value to compare the value of matching nodes against. It is
+        query is an optional value to compare the value of matching nodes against. It is
         either a single string, in which case only the last node is filtered, or it is a tuple
-        of values corresponding to the last len(filter) parts. It may not be a 'name_sep'
+        of values corresponding to the last len(query) parts. It may not be a 'name_sep'
         delimited string, because values are arbitrary values
 
         Examples:
@@ -267,26 +267,26 @@ class ZPLnode(object):
             thing = cfg.get("thing", "flu")
             assert thing.value == "flu"
 
-            bar = cfg.get( ("thing", "bar"), filter="bar" )   # get the bar of the any 'thing' node where the value is "bar"
+            bar = cfg.get( ("thing", "bar"), query="bar" )   # get the bar of the any 'thing' node where the value is "bar"
             assert bar.value == "bar"
 
-            bar = cfg.get( ("thing", "bar"), filter=("flu", None) )   # get the 'bar' of the 'thing=flu' node
+            bar = cfg.get( ("thing", "bar"), query=("flu", None) )   # get the 'bar' of the 'thing=flu' node
             assert bar.value == "bat"
         """
 
         # if this is a string, turn it into a list
         if (hasattr(path, 'encode')): path = path.split(name_sep)
 
-        # check the filter; if it is a string, turn it into a list. If it is short, pad it with 'None'
-        if (hasattr(filter, 'encode')): filter = (filter,)
+        # check the query; if it is a string, turn it into a list. If it is short, pad it with 'None'
+        if (hasattr(query, 'encode')): query = (query,)
 
-        if (len(filter) > len(path)) : raise ValueError("too many filter parameters for path", "path="+str(path), "filter="+str(filter))
+        if (len(query) > len(path)) : raise ValueError("too many query parameters for path", "path="+str(path), "query="+str(query))
 
-        # left-pad the filter with None
-        filter = (None,)*(len(path)-len(filter)) + filter
+        # left-pad the query with None
+        query = (None,)*(len(path)-len(query)) + query
 
-        # Turn the parts and filters into a list that can be sliced
-        args = [ x for x in zip(path, filter) ]
+        # Turn the parts and querys into a list that can be sliced
+        args = [ x for x in zip(path, query) ]
         match, node = self.__match(args)
 
         result = node if match else None

--- a/pyzpl/__init__.py
+++ b/pyzpl/__init__.py
@@ -57,16 +57,19 @@ import io
 import re
 import sys
 import collections
-import operator as op
+import operator
 
 __version__ = '0.1.9'
 
 PY2 = sys.version_info.major < 3
 
-str = unicode if PY2 else str   # noqa
-
-vitems = op.methodcaller('viewitems') if PY2 else op.methodcaller('items')
-
+if PY2:
+    str = unicode
+    vitems = operator.methodcaller('viewitems')
+else:                                     #python 3
+    # str supports necessary decode
+    vitems = operator.methodcaller('items')
+    
 
 NAME_RE = re.compile(r"^(?P<propname>[A-Z0-9\$_\-@\.&+/]+).*$", re.VERBOSE | re.IGNORECASE)
 
@@ -82,8 +85,23 @@ NAME_VALUE_PAIR_RE = re.compile(r"""
     $
 """, re.VERBOSE | re.IGNORECASE)
 
+    
+def load_stream(bytes_stream, encoding='utf-8', emit_empty=False):
+    """for propname,value in load_stream(linelist, encoding='utf-8', emit_empty=False): ...
 
-def load_stream(bytes_stream, encoding='utf-8'):
+    Arguments:
+        linelist   - an iterable that yields one ZPL line at a time ('file' is a suitable
+                     argument)
+        encoding   - character encoding. Any value suitable for str.decode(), default is 'utf-8'
+        emit_empty - whether to emit value-less nodes or not (default=false)
+
+    This is a generator function, yielding one tuple of (propname, value) for each name/value
+    property in the stream. The 'propname' is itself a tuple of components, representing the
+    hierarchical path to the property.
+
+    As a stream parser, it carries no state (other that the property's place in the hierarchy).
+    """
+
     propname_stack = tuple()
     prev_indent_lvl = 0
     for lineno, raw_line in enumerate(bytes_stream):
@@ -91,30 +109,29 @@ def load_stream(bytes_stream, encoding='utf-8'):
         cleaned_line = decoded_line.rstrip("\r\n")
         line = cleaned_line.lstrip(" ")
         if not line:
-            continue
+            continue                      # skip blank lines
         spaces = len(cleaned_line) - len(line)
 
         if spaces % 4 != 0:
             msgfmt = "Illegal indent on line {}, must be a multiple of 4\n\t{}"
-            raise ValueError(msgfmt.format(spaces, repr(cleaned_line)))
+            raise ValueError(msgfmt.format(lineno, repr(cleaned_line)))
 
         indent_lvl = spaces // 4
         if indent_lvl <= prev_indent_lvl:
             propname_stack = propname_stack[:indent_lvl]
+            # this represents an outdent?
 
         nv_pair_match = NAME_VALUE_PAIR_RE.match(line)
         if nv_pair_match:
-            propname = nv_pair_match.group(1).strip()
-            value = nv_pair_match.group(2)
-            propnames = propname_stack + (propname,)
+            propname_stack += (nv_pair_match.group(1).strip(),)
             prev_indent_lvl = indent_lvl
-            yield propnames, value
+            yield propname_stack, nv_pair_match.group(2)
         else:
             propname_match = NAME_RE.match(line)
             if propname_match:
                 propname_stack += (propname_match.group(1),)
                 prev_indent_lvl = indent_lvl
-
+                if emit_empty: yield propname_stack, ""
 
 def load(
         bytes_stream,
@@ -122,6 +139,16 @@ def load(
         flat=False,
         name_sep=":",
         dict_cls=collections.OrderedDict):
+    """tree = load(linelist, encoding='utf-8', flat=False, name_sep=':', dict_cls=collections.OrderedDict)
+    
+    loads a ZPL stream (an iterable yielding one line at a time) into an mapping object
+    (instance of dict_cls). Internally, it calls load_stream, passing the linelist and the
+    encoding, and assembles the results into the collection.
+
+    Note that this interface does not allow for repeated property names at the same level. The
+    ZPL spec is not clear about if this is defined behavior or not. It also does not support
+    properties having both values and children.
+    """
 
     tree = dict_cls()
     for propnames, value in load_stream(bytes_stream, encoding=encoding):
@@ -178,6 +205,165 @@ def dump_lines(tree_items, name_sep=":"):
 def dumps(tree, *args, **kwargs):
     lines = dump_lines(vitems(tree), *args, **kwargs)
     return "\n".join(lines) + "\n"
+
+
+class ZPLnode(object):
+    """ZPLnode(name=root, value=None)
+
+    This class represents a single node in a ZPL hierarchy. Per the ZPL specification:
+
+        ZPL is designed to represent a property set, where each property has a name
+        and a value. Properties are hierarchical, i.e. properties can contain other
+        properties.
+
+    Also, preserving the stream-like properties of a ZPL sequence, the order in which nodes
+    appear is preserved
+    """
+
+    def __init__(self, **kw):
+        self._name = kw.get("name", "root")
+        self._value = kw.get("value", None)
+        self._parent = kw.get("parent", None)
+        if (self._parent):
+            self._level = self._parent._level + 1
+            self._parent._children.append(self)
+        else:
+            self._level = 0
+        self._children = []
+
+    def get(self, path, filter=(None,), name_sep=':'):
+        """get(path, filter=None, name_sep=':')
+
+        Retrieve the node described by 'path' and (optionally) matching 'filter'
+
+        path is a tuple of names, or a string of 'name_sep' delimited parts, corresponding to
+        the hierarchy of nodes
+
+        filter is an optional value to compare the value of matching nodes against. It is
+        either a single string, in which case only the last node is filtered, or it is a tuple
+        of values corresponding to the last len(filter) parts. It may not be a 'name_sep'
+        delimited string, because values are arbitrary values
+
+        Examples:
+            buffer = b'''
+            thing = foo
+                bar = baz
+
+            thing = flu
+                bar = bat
+
+            thing
+                bar = bar
+
+            depth
+                item
+                    value = 1
+'''
+            cfg = pyzpl.parse_cfg(buffer)
+
+            thing = cfg.get("thing")
+            assert thing.get('bar').value == 'baz'  # first matching 'thing' node
+
+            thing = cfg.get("thing", "flu")
+            assert thing.value == "flu"
+
+            bar = cfg.get( ("thing", "bar"), filter="bar" )   # get the bar of the any 'thing' node where the value is "bar"
+            assert bar.value == "bar"
+
+            bar = cfg.get( ("thing", "bar"), filter=("flu", None) )   # get the 'bar' of the 'thing=flu' node
+            assert bar.value == "bat"
+        """
+
+        # if this is a string, turn it into a list
+        if (hasattr(path, 'encode')): path = path.split(name_sep)
+
+        # check the filter; if it is a string, turn it into a list. If it is short, pad it with 'None'
+        if (hasattr(filter, 'encode')): filter = (filter,)
+
+        if (len(filter) > len(path)) : raise ValueError("too many filter parameters for path", "path="+str(path), "filter="+str(filter))
+
+        # left-pad the filter with None
+        filter = (None,)*(len(path)-len(filter)) + filter
+
+        # Turn the parts and filters into a list that can be sliced
+        args = [ x for x in zip(path, filter) ]
+        match, node = self.__match(args)
+
+        result = node if match else None
+        return result
+
+    def __match(self, args):
+        node = None
+        part, filt = args[0]
+
+        for child in self.children:
+            match = (child.name == part and ( (not filt) or filt == child.value ))
+            if match:
+                node = child
+                if len(args) > 1:
+                    match, node = child.__match(args[1:])
+                if match: break
+            
+        return match, node
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def value(self):
+        return self._value
+    @value.setter
+    def value(self, val):
+        self._value = val
+
+    @property
+    def level(self):
+        return self._level
+
+    @property
+    def children(self):
+        return iter(self._children)       # todo if only an iterable is appropriate.
+
+    def __str__(self):
+        result = ""
+        if (self.level != 0):             # don't print node information for the root node
+#            result += str(self.level) + ":"
+            result += "    " * (self.level-1)
+            result += str(self.name);
+            if (self.value): result += " = " + self.value
+
+        for child in self.children:
+            result += "\n" + str(child)
+
+        return result
+
+def load_cfg(bytes_stream, encoding='utf-8'):
+    """root_node = load_cfg(linelist, encoding='utf-8')
+
+    loads a ZPL stream (an iterable yielding one line at a time) into a hiearchy of ZPLnode
+    instances, returning the root node.
+    """
+
+    print("Entering load_cfg")
+    root = ZPLnode()
+    roots = [root,]
+    prev = root
+    for propnames, value in load_stream(bytes_stream, encoding=encoding, emit_empty=True):
+        # call load_stream with emit_empty=True to make it return all nodes. This simplifies
+        # creating sub-trees, and ensures that the maximum increate in depth is 1
+        level = len(propnames)
+
+        # Because the maximum increase in level is 1, and we slice 'roots' to the current
+        # level, this works regardless of indent
+        roots = roots[:level]         # levels are 0-based, so the length is always 1 more than the level
+        parent = roots[level-1]
+        name = propnames[-1]
+        child = ZPLnode( name=name, value=value, parent=parent )
+        roots.append(child)
+        prev = child
+
+    return root
 
 
 def main(args=sys.argv[1:]):

--- a/tests.py
+++ b/tests.py
@@ -188,13 +188,13 @@ def cfgtester(data, *args, **kw):
     assert value.value == "1"             # all values are strings
 
     # filtering
-    thing = cfg.get("thing", "flu")
+    thing = cfg.get("thing", query="flu")
     assert thing.value == "flu"
 
-    bar1 = cfg.get( ("thing", "bar"), filter="bar" )   # get the bar of the any 'thing' node where the value is "bar"
+    bar1 = cfg.get( ("thing", "bar"), query="bar" )   # get the bar of the any 'thing' node where the value is "bar"
     assert bar1.value == "bar"
 
-    bar1 = cfg.get( ("thing", "bar"), filter=("flu", None) )   # get the 'bar' of the 'thing=flu' node
+    bar1 = cfg.get( ("thing", "bar"), query=("flu", None) )   # get the 'bar' of the 'thing=flu' node
     assert bar1.value == "bat"
 
     # iteration

--- a/tests.py
+++ b/tests.py
@@ -300,11 +300,9 @@ def test_hiearchical():
 
     # "subscript" access
     node = cfg["node"]                    # get the first node
-    assert node != None
     assert node.value == "basement"
 
     node = cfg["node=front door"]         # query selection
-    assert node != None
     assert node.value == "front door"
 
     # Negative test
@@ -319,14 +317,16 @@ def test_hiearchical():
 
     # get() access
     node = cfg.get("node")                # get the first node (unqualified)
+    assert node != None
     assert node.value == "basement"
 
     # sub-element navigation
     ip1 = node.get("ip")                  # relative to the sub-tree retrieved above
     ip2 = cfg.get( ("node","ip") )        # still the first node, hierarchicaly qualified
     ip3 = cfg.get("node:ip")              # string based fully qualified
-    assert ip1.value == "10.1.2.3"
+    assert ip1 != None
     assert ip1 == ip2 == ip3
+    assert ip1.value == "10.1.2.3"
 
     auth = cfg.get("authorized_users:authorization")
     assert auth != None
@@ -334,11 +334,11 @@ def test_hiearchical():
 
     # chained "indexing"
     auth = cfg["authorized_users"]["authorization"]
-    assert auth != None
     assert auth.value == "simple"
 
     # filtering
     node = cfg.get("node", query="nursery")
+    assert node != None
     assert node.value == "nursery"
 
     # When the query is the leaf node, a simple query may be used
@@ -351,7 +351,9 @@ def test_hiearchical():
     #   --- path ---            --- query ---
     #   ('a', 'b', 'c')         ('1', None)
     # is equivalent to
-    #   cfg.get('a', query=None).get('b', query='1').get('c', query=None)
+    #   ('a', 'b', 'c')         (None, '1', None)
+    # or
+    #   cfg.get('a').get('b', query='1').get('c')
 
     priv = cfg.get( ("authorized_users", "user", "privilege"), query=("alex", None) )
     assert priv != None
@@ -359,8 +361,8 @@ def test_hiearchical():
 
     # iteration
     children = [ child for child in cfg.children ]
-
     assert len(children) == 4
+
     node = children[0]
     assert node.name == "node"
     assert node.value == "basement"


### PR DESCRIPTION
This request extends **pyzpl** to provide a queryable, hierarchical configuration file type interface. All existing tests pass, as well as the new one added for this capability.